### PR TITLE
Add cross-env to enable Windows builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
       },
       "devDependencies": {
         "@graphql-eslint/eslint-plugin": "^3.20.1",
+        "cross-env": "^7.0.3",
         "eslint": "^8.52.0",
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-jsx-a11y": "^6.8.0",
@@ -4969,6 +4970,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.1.0",
   "description": "a pawtastic WebApp to enchance your Chaster experience",
   "scripts": {
-    "start": "NODE_ENV=development webpack serve",
+    "start": "cross-env NODE_ENV=development webpack serve",
     "build": "webpack",
-    "build:dev": "NODE_ENV=development webpack",
-    "build:prod": "NODE_ENV=production webpack",
-    "serve": "NODE_ENV=production webpack && npx http-server -c-1 --proxy=http://127.0.0.1:8080?",
-    "stats": "NODE_ENV=production webpack --profile --json > schema/stats.json && npx webpack-bundle-analyzer schema/stats.json public",
+    "build:dev": "cross-env NODE_ENV=development webpack",
+    "build:prod": "cross-env NODE_ENV=production webpack",
+    "serve": "cross-env NODE_ENV=production webpack && npx http-server -c-1 --proxy=http://127.0.0.1:8080?",
+    "stats": "cross-env NODE_ENV=production webpack --profile --json > schema/stats.json && npx webpack-bundle-analyzer schema/stats.json public",
     "lint": "eslint . --ext .js,.jsx --ignore-path=.gitignore",
     "api": "cd schema && curl https://api.chaster.app/api-json > api.json && npx @openapitools/openapi-generator-cli generate -i api.json -g graphql-schema --global-property skipFormModel=false"
   },
@@ -79,6 +79,7 @@
   },
   "devDependencies": {
     "@graphql-eslint/eslint-plugin": "^3.20.1",
+    "cross-env": "^7.0.3",
     "eslint": "^8.52.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",


### PR DESCRIPTION
Windows can't handle the environment variables like Linux. Adding the cross-env module allows this to build on Windows.