### PR TITLE
Switch the chart from UTC to local times

### DIFF
--- a/app/components/Chart.jsx
+++ b/app/components/Chart.jsx
@@ -29,7 +29,7 @@ function Chart({ unlockDate, remTime, timeChanges, pillory, freeze, timer, lock,
     ],
     legend: { enabled: true, align: 'center', verticalAlign: 'bottom' },
     time: {
-      useUTC: false,
+      useUTC: false
     },
     exporting: {
       filename: 'lockChart', sourceWidth: 1800, sourceHeight: 600, fallbackToExportServer: false,

--- a/app/components/Chart.jsx
+++ b/app/components/Chart.jsx
@@ -28,6 +28,9 @@ function Chart({ unlockDate, remTime, timeChanges, pillory, freeze, timer, lock,
       { title: { text: 'remaining days' } }
     ],
     legend: { enabled: true, align: 'center', verticalAlign: 'bottom' },
+    time: {
+      useUTC: false,
+    },
     exporting: {
       filename: 'lockChart', sourceWidth: 1800, sourceHeight: 600, fallbackToExportServer: false,
       buttons: { contextButton: { menuItems: ['downloadJSON', 'separator', 'viewFullscreen', 'printChart', 'separator', 'downloadPNG', 'downloadJPEG', 'downloadPDF', 'downloadSVG'] } },


### PR DESCRIPTION
Given that most of the times in KittenLocks is in local time, having the chart in UTC is confusing. This PR tells highcharts to switch to using local times.

Addresses issue #4 