### PR TITLE
use a JsonView rather than showing unformatted JSON

### DIFF
--- a/app/components/LockHistory.jsx
+++ b/app/components/LockHistory.jsx
@@ -19,7 +19,7 @@ const HistoryList = memo(({ history }) => {
           <Typography variant="caption">{e.createdAt.toLocaleString()}</Typography>
         </AccordionSummary>
         <AccordionDetails>
-          {JSON.stringify(e)}
+          <JsonView src={e}/>
         </AccordionDetails>
       </Accordion>
       <Divider/>

--- a/app/components/LockHistory.jsx
+++ b/app/components/LockHistory.jsx
@@ -12,7 +12,7 @@ import { Virtuoso } from 'react-virtuoso';
 const HistoryList = memo(({ history }) => {
   const itemContent = useCallback((i, e) => (
     <>
-      <Accordion>
+      <Accordion TransitionProps={{ mountOnEnter: true }}>
         <AccordionSummary expandIcon={<ExpandMore/>}>
           <Typography flexGrow={1}>{e.title}</Typography>
           <Avatar alt={e.role === 'extension' ? e.extension : e.user?.username || 'unknown'} sx={{ width: 24, height: 24, mr: 1 }} src={e.role === 'extension' ? null : e.user?.avatarUrl || null}><SmartToyTwoTone/></Avatar>


### PR DESCRIPTION
The JSON shown when the history accordion is expanded was a string with unformatted JSON, which was hard to visually parse. This PR uses the JsonView instead, making it easier to visually parse the data.